### PR TITLE
Include decorators in `Class` and `FunctionDef` range

### DIFF
--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -941,7 +941,7 @@ WithItem<Goal>: ast::Withitem = {
 };
 
 FuncDef: ast::Stmt = {
-    <decorator_list:Decorator*> <location:@L> <is_async:"async"?> "def" <name:Identifier> <args:Parameters> <r:("->" <Test<"all">>)?> ":" <body:Suite>  => {
+     <location:@L> <decorator_list:Decorator*> <is_async:"async"?> "def" <name:Identifier> <args:Parameters> <r:("->" <Test<"all">>)?> ":" <body:Suite>  => {
         let args = Box::new(args);
         let returns = r.map(|x| Box::new(x));
         let end_location = body.last().unwrap().end();
@@ -1114,7 +1114,7 @@ KwargParameter<ArgType>: Option<Box<ast::Arg>> = {
 };
 
 ClassDef: ast::Stmt = {
-    <decorator_list:Decorator*> <location:@L> "class" <name:Identifier> <a:("(" ArgumentList ")")?> ":" <body:Suite> => {
+    <location:@L> <decorator_list:Decorator*> "class" <name:Identifier> <a:("(" ArgumentList ")")?> ":" <body:Suite> => {
         let (bases, keywords) = match a {
             Some((_, arg, _)) => (arg.args, arg.keywords),
             None => (vec![], vec![]),

--- a/parser/src/python.rs
+++ b/parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 47b783562ed1a6b737bc43a6a32667a7c2d2a8d317902061795979684331efe1
+// sha3: 88e0a6541abcb74a7f9a43329b3ec7bb28808f8a49dc0cb928cb8fa2a2820910
 use crate::{
     ast::{self as ast, Ranged},
     lexer::{LexicalError, LexicalErrorType},
@@ -30697,8 +30697,8 @@ fn __action154<
 #[allow(clippy::too_many_arguments)]
 fn __action155<
 >(
-    (_, decorator_list, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     (_, location, _): (TextSize, TextSize, TextSize),
+    (_, decorator_list, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     (_, is_async, _): (TextSize, core::option::Option<token::Tok>, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, name, _): (TextSize, ast::Identifier, TextSize),
@@ -30793,8 +30793,8 @@ fn __action159<
 #[allow(clippy::too_many_arguments)]
 fn __action160<
 >(
-    (_, decorator_list, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     (_, location, _): (TextSize, TextSize, TextSize),
+    (_, decorator_list, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, name, _): (TextSize, ast::Identifier, TextSize),
     (_, a, _): (TextSize, core::option::Option<(token::Tok, ArgumentList, token::Tok)>, TextSize),
@@ -37437,8 +37437,8 @@ fn __action634<
 #[allow(clippy::too_many_arguments)]
 fn __action635<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-    __1: (TextSize, TextSize, TextSize),
+    __0: (TextSize, TextSize, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, token::Tok, TextSize),
     __4: (TextSize, ast::Identifier, TextSize),
@@ -37470,8 +37470,8 @@ fn __action635<
 #[allow(clippy::too_many_arguments)]
 fn __action636<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-    __1: (TextSize, TextSize, TextSize),
+    __0: (TextSize, TextSize, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
     __4: (TextSize, ast::Arguments, TextSize),
@@ -37640,8 +37640,8 @@ fn __action641<
 #[allow(clippy::too_many_arguments)]
 fn __action642<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-    __1: (TextSize, TextSize, TextSize),
+    __0: (TextSize, TextSize, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
     __4: (TextSize, token::Tok, TextSize),
@@ -37673,8 +37673,8 @@ fn __action642<
 #[allow(clippy::too_many_arguments)]
 fn __action643<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-    __1: (TextSize, TextSize, TextSize),
+    __0: (TextSize, TextSize, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
     __4: (TextSize, token::Tok, TextSize),
@@ -39942,16 +39942,16 @@ fn __action736<
     __7: (TextSize, ast::Suite, TextSize),
 ) -> ast::Stmt
 {
-    let __start0 = __0.2;
-    let __end0 = __1.0;
+    let __start0 = __0.0;
+    let __end0 = __0.0;
     let __temp0 = __action373(
         &__start0,
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action642(
-        __0,
         __temp0,
+        __0,
         __1,
         __2,
         __3,
@@ -39972,16 +39972,16 @@ fn __action737<
     __4: (TextSize, ast::Suite, TextSize),
 ) -> ast::Stmt
 {
-    let __start0 = __0.2;
-    let __end0 = __1.0;
+    let __start0 = __0.0;
+    let __end0 = __0.0;
     let __temp0 = __action373(
         &__start0,
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action643(
-        __0,
         __temp0,
+        __0,
         __1,
         __2,
         __3,
@@ -40965,16 +40965,16 @@ fn __action775<
     __7: (TextSize, ast::Suite, TextSize),
 ) -> ast::Stmt
 {
-    let __start0 = __0.2;
-    let __end0 = __1.0;
+    let __start0 = __0.0;
+    let __end0 = __0.0;
     let __temp0 = __action373(
         &__start0,
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action635(
-        __0,
         __temp0,
+        __0,
         __1,
         __2,
         __3,
@@ -40997,16 +40997,16 @@ fn __action776<
     __6: (TextSize, ast::Suite, TextSize),
 ) -> ast::Stmt
 {
-    let __start0 = __0.2;
-    let __end0 = __1.0;
+    let __start0 = __0.0;
+    let __end0 = __0.0;
     let __temp0 = __action373(
         &__start0,
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action636(
-        __0,
         __temp0,
+        __0,
         __1,
         __2,
         __3,


### PR DESCRIPTION
This PR changes the `ClassDef` and `FunctionDef` definitions to include the range of their decorators. 

## Example

```py
@test
def f(): 
	pass
```

* Before: The functions' range was from line **2**, column 0 to line 3, column 9
* New: The functions' range spans from line **1**, column 0 to line 3, column 9 (includes the `@test` decorator)

## Motivation

This change is because these are the only nodes for where the property `parent.range.includes(child.range)` does not hold. The fact that this property is not respected means it is e.g. impossible to use a binary search over the AST to find a node by its range. 

## Downsides

The main downside that I'm aware of is that diagnostics using `range.start` to compute the line index for functions and classes may now incorrectly point to the line of the function's decorator instead of the function definition. I don't know if this is a problem for RustPython. Ruff already uses custom infrastructure to extract the range of the function name only to limit the diagnostic range (and e.g. avoid highlighting the whole function or class including the body)

## Ruff

https://github.com/charliermarsh/ruff/pull/4467

