### PR TITLE
Avoid removing elements from the head of a vec

### DIFF
--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -114,11 +114,11 @@ ExpressionStatement: ast::Stmt = {
             let mut targets = vec![set_context(expression, ast::ExprContext::Store)];
             let mut values = suffix;
 
-            while values.len() > 1 {
-                targets.push(set_context(values.remove(0), ast::ExprContext::Store));
-            }
+            let value = Box::new(values.pop().unwrap());
 
-            let value = Box::new(values.into_iter().next().unwrap());
+            for target in values {
+                targets.push(set_context(target, ast::ExprContext::Store));
+            }
 
             ast::Stmt::Assign(
                 ast::StmtAssign { targets, value, type_comment: None, range: (location..end_location).into() }

--- a/parser/src/python.rs
+++ b/parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: a33e9abb4be2a3730161519ce0f298452edbc50335b9e0c812d5a1730f1d8816
+// sha3: 978b442f9e59b7597dbf53a952a1528232a8ad35ee3a9c9cae78d3d3234a5abe
 use crate::{
     ast::{self as ast, Ranged},
     lexer::{LexicalError, LexicalErrorType},
@@ -28915,11 +28915,11 @@ fn __action24<
             let mut targets = vec![set_context(expression, ast::ExprContext::Store)];
             let mut values = suffix;
 
-            while values.len() > 1 {
-                targets.push(set_context(values.remove(0), ast::ExprContext::Store));
-            }
+            let value = Box::new(values.pop().unwrap());
 
-            let value = Box::new(values.into_iter().next().unwrap());
+            for target in values {
+                targets.push(set_context(target, ast::ExprContext::Store));
+            }
 
             ast::Stmt::Assign(
                 ast::StmtAssign { targets, value, type_comment: None, range: (location..end_location).into() }


### PR DESCRIPTION
This changes the parsing of `ExpressionStatement` to use `pop` with an `IntoIterator` instead of removing elements from the beginning of the vec. Removing elements from the beginning involves moving all following elements by one offset.

I don't expect this to improve performance significantly because it's rare that `values` contains more than a few elements.