### PR TITLE
Fix `TypeAliasName` to store name instead of load

### DIFF
--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -981,7 +981,7 @@ FuncDef: ast::Stmt = {
 
 TypeAliasName: ast::Expr = {
     <location:@L> <name:Identifier> <end_location:@R> => ast::Expr::Name(
-        ast::ExprName { id: name, ctx: ast::ExprContext::Load, range: (location..end_location).into() },
+        ast::ExprName { id: name, ctx: ast::ExprContext::Store, range: (location..end_location).into() },
     ),
 }
 

--- a/parser/src/python.rs
+++ b/parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 3831150e20de8eaf8849292a753e75259c3c34703bbfa26319e8faf5f9a853b5
+// sha3: de5ffc51d44962eb297cbbf668fae33652eed69586405ebef2229fc02d183bc8
 use crate::{
     ast::{self as ast, Ranged, bigint::BigInt},
     lexer::{LexicalError, LexicalErrorType},
@@ -32200,7 +32200,7 @@ fn __action159<
 ) -> ast::Expr
 {
     ast::Expr::Name(
-        ast::ExprName { id: name, ctx: ast::ExprContext::Load, range: (location..end_location).into() },
+        ast::ExprName { id: name, ctx: ast::ExprContext::Store, range: (location..end_location).into() },
     )
 }
 

--- a/parser/src/snapshots/rustpython_parser__parser__tests__parse_type_declaration.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__parse_type_declaration.snap
@@ -12,7 +12,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [],
@@ -36,7 +36,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [],
@@ -75,7 +75,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [],
@@ -114,7 +114,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [
@@ -193,7 +193,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [
@@ -227,7 +227,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [
@@ -306,7 +306,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [
@@ -382,7 +382,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [
@@ -468,7 +468,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [
@@ -571,7 +571,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "type",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [],
@@ -595,7 +595,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "match",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [],
@@ -619,7 +619,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "case",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [],
@@ -643,7 +643,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "foo",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [],
@@ -667,7 +667,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "foo",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [],
@@ -691,7 +691,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "foo",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [],
@@ -715,7 +715,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [],
@@ -739,7 +739,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [],
@@ -763,7 +763,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [],
@@ -787,7 +787,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [],
@@ -811,7 +811,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [
@@ -845,7 +845,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [
@@ -879,7 +879,7 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     id: Identifier(
                         "X",
                     ),
-                    ctx: Load,
+                    ctx: Store,
                 },
             ),
             type_params: [


### PR DESCRIPTION
`type NAME = ...` was previously being treated as an attempt to load the `NAME` when we actually want to store `NAME` as a new binding.

