### PR TITLE
Added num/malachite features for format crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rustpython-parser-vendored = { path = "vendored", version = "0.3.0" }
 rustpython-ast = { path = "ast", default-features = false, version = "0.3.0" }
 rustpython-parser-core = { path = "core", features = [], version = "0.3.0" }
 rustpython-literal = { path = "literal", version = "0.3.0" }
-rustpython-format = { path = "format", version = "0.3.0" }
+rustpython-format = { path = "format", default-features = false, version = "0.3.0" }
 rustpython-parser = { path = "parser", default-features = false, version = "0.3.0" }
 
 anyhow = "1.0.45"

--- a/ast/Cargo.toml
+++ b/ast/Cargo.toml
@@ -16,6 +16,8 @@ fold = []
 unparse = ["rustpython-literal"]
 visitor = []
 all-nodes-with-ranges = []
+malachite-bigint = ["dep:malachite-bigint"]
+num-bigint = ["dep:num-bigint"]
 
 [dependencies]
 rustpython-parser-core = { workspace = true }

--- a/ast/Cargo.toml
+++ b/ast/Cargo.toml
@@ -16,8 +16,6 @@ fold = []
 unparse = ["rustpython-literal"]
 visitor = []
 all-nodes-with-ranges = []
-malachite-bigint = ["dep:malachite-bigint"]
-num-bigint = ["dep:num-bigint"]
 
 [dependencies]
 rustpython-parser-core = { workspace = true }

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -8,10 +8,16 @@ repository = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = ["malachite-bigint"]
+malachite-bigint = ["dep:malachite-bigint"]
+num-bigint = ["dep:num-bigint"]
+
 [dependencies]
 rustpython-literal = { workspace = true }
 
 bitflags = { workspace = true }
 itertools = { workspace = true }
-malachite-bigint = { workspace = true }
+malachite-bigint = { workspace = true, optional = true }
+num-bigint = { workspace = true, optional = true }
 num-traits = { workspace = true }

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -10,8 +10,6 @@ rust-version = { workspace = true }
 
 [features]
 default = ["malachite-bigint"]
-malachite-bigint = ["dep:malachite-bigint"]
-num-bigint = ["dep:num-bigint"]
 
 [dependencies]
 rustpython-literal = { workspace = true }

--- a/format/src/bigint.rs
+++ b/format/src/bigint.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "malachite-bigint")]
+pub use malachite_bigint::{BigInt, Sign};
+#[cfg(feature = "num-bigint")]
+pub use num_bigint::{BigInt, Sign};

--- a/format/src/cformat.rs
+++ b/format/src/cformat.rs
@@ -1,10 +1,7 @@
 //! Implementation of Printf-Style string formatting
 //! as per the [Python Docs](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting).
+use crate::bigint::{BigInt, Sign};
 use bitflags::bitflags;
-#[cfg(feature = "malachite-bigint")]
-use malachite_bigint::{BigInt, Sign};
-#[cfg(feature = "num-bigint")]
-use num_bigint::{BigInt, Sign};
 use num_traits::Signed;
 use rustpython_literal::{float, format::Case};
 use std::{

--- a/format/src/cformat.rs
+++ b/format/src/cformat.rs
@@ -1,7 +1,10 @@
 //! Implementation of Printf-Style string formatting
 //! as per the [Python Docs](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting).
 use bitflags::bitflags;
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::{BigInt, Sign};
+#[cfg(feature = "num-bigint")]
+use num_bigint::{BigInt, Sign};
 use num_traits::Signed;
 use rustpython_literal::{float, format::Case};
 use std::{

--- a/format/src/format.rs
+++ b/format/src/format.rs
@@ -1,8 +1,5 @@
+use crate::bigint::{BigInt, Sign};
 use itertools::{Itertools, PeekingNext};
-#[cfg(feature = "malachite-bigint")]
-use malachite_bigint::{BigInt, Sign};
-#[cfg(feature = "num-bigint")]
-use num_bigint::{BigInt, Sign};
 use num_traits::FromPrimitive;
 use num_traits::{cast::ToPrimitive, Signed};
 use rustpython_literal::float;

--- a/format/src/format.rs
+++ b/format/src/format.rs
@@ -1,5 +1,8 @@
 use itertools::{Itertools, PeekingNext};
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::{BigInt, Sign};
+#[cfg(feature = "num-bigint")]
+use num_bigint::{BigInt, Sign};
 use num_traits::FromPrimitive;
 use num_traits::{cast::ToPrimitive, Signed};
 use rustpython_literal::float;

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -1,3 +1,4 @@
+mod bigint;
 pub mod cformat;
 mod format;
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -24,7 +24,7 @@ phf_codegen = "0.11.1"
 tiny-keccak = { version = "2", features = ["sha3"] }
 
 [dependencies]
-rustpython-ast = { workspace = true }
+rustpython-ast = { workspace = true, default-features = false }
 rustpython-parser-core = { workspace = true }
 
 itertools = { workspace = true }


### PR DESCRIPTION
To make `malachite-bigint` optional and `num-bigint` optin for RustPython `format` crate needs the features.
Trying to solve for https://github.com/RustPython/RustPython/issues/5130#issuecomment-1853251581