### PR TITLE
Fix the invalid license name for cargo-deny

### DIFF
--- a/vendored/Cargo.toml
+++ b/vendored/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustpython-parser-vendored"
 description = "RustPython parser vendored third-party crates."
 authors = ["RustPython Team", "and the original authors of the vendored modules"]
-license = "Various"
+license = "MIT"
 edition = { workspace = true }
 version = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
Both the vendored crates are `MIT` licensed(currently).
So changed the license of the crate to `MIT`.

This is to fix errors while using [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny)

```
error[unlicensed]: rustpython-parser-vendored = 0.3.1 is unlicensed
  ┌─ rustpython-parser-vendored 0.3.1 (git+https://github.com/h7kanna/Parser.git?rev=22a1f5aa9eb4a7e8bfd95bb450414788044f8bb5#22a1f5aa9eb4a7e8bfd95bb450414788044f8bb5):2:9
  │
2 │ name = "rustpython-parser-vendored"
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ a valid license expression could not be retrieved for the crate
3 │ version = "0.3.1"
4 │ license = "Various"
  │            ------- unknown term

```